### PR TITLE
build: Add missing @InputDirectory annotation to romToolsDir

### DIFF
--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -158,7 +158,10 @@ tasks.register<Copy>("copyRomTools") {
     }
 }
 
+import org.gradle.api.tasks.InputDirectory
+
 abstract class VerifyRomToolsTask : DefaultTask() {
+    @get:InputDirectory
     @get:Optional
     abstract val romToolsDir: DirectoryProperty
 


### PR DESCRIPTION
The VerifyRomToolsTask was causing the build to fail because the romToolsDir property was missing an input annotation.

This change adds the @InputDirectory annotation to the romToolsDir property, which should resolve the build failure.