### PR TITLE
Fix romtools build

### DIFF
--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -168,11 +168,10 @@ abstract class VerifyRomToolsTask : DefaultTask() {
     abstract val romToolsPath: Property<String>
 
     /**
-     * Verifies that the configured ROM tools directory exists.
+     * Verifies that the configured ROM tools directory (`romToolsPath`) exists and logs the result.
      *
-     * If `romToolsDir` is unset or the directory does not exist, logs a warning that ROM functionality may be limited.
-     * If the directory exists, logs a lifecycle message with its absolute path. This check is informational and does not
-     * fail the build when the directory is missing.
+     * If `romToolsPath` is unset or points to a non-existent directory, a warning is logged and the task does not fail the build.
+     * If the directory exists, a lifecycle message is logged with its absolute path.
      */
     @TaskAction
     fun verify() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the verification task’s behavior in the plugin documentation.
  * Updated wording to consistently reference the configured tools path and note that the verification step logs its result.
  * Explained error handling: if the tools path is unset or points to a non-existent directory, a warning is logged and the task does not fail; if the directory exists, a lifecycle message with the absolute path is logged.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->