### PR TITLE
Fix Firebase Performance plugin version and AGP conflict

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    alias(libs.plugins.android.application) version "9.0.0-alpha02"
+    alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ firebaseBom = "34.2.0"
 firebaseCrashlytics = "3.0.6"
 firebaseCrashlyticsKtx = "19.4.4"
 firebasePerf = "22.0.1"
+firebasePerfPlugin = "1.4.2"
 googleAuth = "21.4.0"
 googleAuthApiPhone = "18.2.0"
 googleIdentity = "18.1.0"
@@ -80,7 +81,7 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
-firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
- Updated `gradle/libs.versions.toml` to use the correct version for the Firebase Performance plugin (1.4.2) while keeping the library version at 22.0.1. The plugin and library have different versioning schemes, and this change resolves the build error caused by using the same version for both.
- Removed the hardcoded Android Gradle Plugin version from `app/build.gradle.kts`. This resolves a version conflict and allows the AGP version to be managed centrally in `gradle/libs.versions.toml`.