### PR TITLE
Fix multiple build errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
-    alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.spotless) apply true // Spotless is applied directly to the root for project-wide formatting
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.openapi.generator) apply false


### PR DESCRIPTION
This commit resolves a series of build failures:

1.  **Disable incompatible Firebase Performance plugin:** The Firebase Performance plugin is currently incompatible with AGP 9.0. This change disables the plugin as a temporary workaround by removing it from all build configuration files.
2.  **Remove conflicting Kotlin configuration:** A duplicate `kotlin` block in `app/build.gradle.kts` was causing an "extension already registered" error. This has been removed.
3.  **Remove hardcoded AGP version:** The `app/build.gradle.kts` file had a hardcoded AGP version, which has been removed to avoid conflicts with the version defined in `libs.versions.toml`.