### PR TITLE
Fix multiple cascading build failures

### DIFF
--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -169,7 +169,6 @@ tasks.register<Copy>("copyRomTools") {
 }
 
 abstract class VerifyRomToolsTask : DefaultTask() {
-    @get:InputDirectory
     @get:Optional
     abstract val romToolsDir: DirectoryProperty
 


### PR DESCRIPTION
This commit resolves a series of build failures that were preventing the project from building successfully.

The following changes are included:

1.  **Disable incompatible Firebase Performance plugin:** The Firebase Performance plugin is currently incompatible with AGP 9.0. This change disables the plugin as a temporary workaround by removing it from all build configuration files (`app/build.gradle.kts`, root `build.gradle.kts`, and `gradle/libs.versions.toml`).
2.  **Remove conflicting Kotlin configuration:** A duplicate `kotlin` block in `app/build.gradle.kts` was causing an "extension already registered" error. This has been removed.
3.  **Remove hardcoded AGP version:** The `app/build.gradle.kts` file had a hardcoded AGP version, which has been removed to avoid conflicts with the version defined in `libs.versions.toml`.
4.  **Fix `verifyRomTools` task dependency:** The `:romtools:verifyRomTools` task was failing because it was running before its required input directory was created. The `@InputDirectory` annotation was removed from the task to prevent a configuration-time check, and a `dependsOn` dependency was added to ensure the directory is created by the `ensureResourceStructure` task before `verifyRomTools` runs.