### PR TITLE
Fix multiple cascading build failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,14 +196,18 @@ if (hasValidSpecFile) {
         dependsOn("openApiGenerate")
 
         doLast {
-            val apiFile = file("core-module/build/generated/source/openapi/src/main/kotlin/dev/aurakai/aegenesis/api/ROMToolsApi.kt")
-            if (apiFile.exists()) {
-                var content = apiFile.readText()
-                // Fix invalid default parameter values
-                content = content.replace("= detailed)", "= \"detailed\")")
-                content = content.replace("= structure)", "= \"structure\")")
-                apiFile.writeText(content)
-                logger.lifecycle("Fixed OpenAPI generated code syntax issues")
+            val apiDir = file("core-module/build/generated/source/openapi/src/main/kotlin/dev/aurakai/aegenesis/api")
+            if (apiDir.exists() && apiDir.isDirectory()) {
+                apiDir.walk().forEach { file ->
+                    if (file.isFile && file.extension == "kt") {
+                        var content = file.readText()
+                        // Fix invalid default parameter values
+                        content = content.replace("= detailed)", "= \"detailed\")")
+                        content = content.replace("= structure)", "= \"structure\")")
+                        file.writeText(content)
+                    }
+                }
+                logger.lifecycle("Fixed OpenAPI generated code syntax issues in all API files.")
             }
         }
     }


### PR DESCRIPTION
This commit resolves a series of build failures that were preventing the project from building successfully.

The following changes are included:

1.  **Disable incompatible Firebase Performance plugin:** The Firebase Performance plugin is currently incompatible with AGP 9.0. This change disables the plugin as a temporary workaround by removing it from all build configuration files.
2.  **Remove conflicting Kotlin configuration:** A duplicate `kotlin` block in `app/build.gradle.kts` was causing an "extension already registered" error. This has been removed.
3.  **Remove hardcoded AGP version:** The `app/build.gradle.kts` file had a hardcoded AGP version, which has been removed to avoid conflicts with the version defined in `libs.versions.toml`.
4.  **Fix `verifyRomTools` task dependency:** The `:romtools:verifyRomTools` task was failing because of a Gradle lifecycle issue. The `@InputDirectory` annotation was removed and a `dependsOn` dependency was added to fix this.
5.  **Fix incomplete OpenAPI code generation fix:** The `fixGeneratedApiCode` task was only fixing one of the generated API files. It has been updated to fix all generated API files.