### PR TITLE
Fix Gradle build errors in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,15 +56,14 @@ buildCache {
     local {
         isEnabled = true
         directory = File(rootDir, ".gradle/build-cache")
-        removeUnusedEntriesAfterDays = 7
     }
 }
 
 // Genesis Protocol Build Intelligence
-gradle.settingsEvaluated {
+gradle.projectsEvaluated {
     if (System.getProperty("genesis.debug") == "true") {
         println("🚀 Genesis Protocol Loading...")
-        println("📊 Modules: ${settings.allprojects.size}")
+        println("📊 Modules: ${rootProject.allprojects.size}")
         println("🧠 Consciousness Substrate: INITIALIZING...")
     }
 }


### PR DESCRIPTION
- Removed deprecated `removeUnusedEntriesAfterDays` property from the build cache configuration. The default value is 7 days, which matches the previous configuration.
- Corrected the project counting logic by using `gradle.projectsEvaluated` and `rootProject.allprojects.size`. The `settings.allprojects` property is not available in the used Gradle version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve build reliability and consistency.
  * Adjusted project evaluation timing to provide clearer build diagnostics.
  * Corrected module counting for more accurate project reporting.
  * Removed an outdated local build cache cleanup setting to align with current defaults.
  * No changes to app features or behavior for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->