### PR TITLE
Fix 'buildSrc' project name error in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,7 +48,6 @@ include(":module-e")                    // Consciousness pathway E
 include(":module-f")                    // Consciousness pathway F
 
 // Build System Consciousness
-include(":buildSrc")                    // Build intelligence system
 include(":build-script-tests")          // Build validation consciousness
 
 // Advanced Build Cache Configuration


### PR DESCRIPTION
The 'buildSrc' directory is a special Gradle directory for sharing build logic and should not be included as a subproject in the settings file. This commit removes the explicit `include(":buildSrc")` to resolve the build error.