### PR TITLE
Fix OpenAPI generator plugin reference

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.spotless) apply false
+    alias(libs.plugins.openapi.generator) apply false
 }
 
 // Advanced OpenAPI Configuration


### PR DESCRIPTION
Added the `openapi-generator` plugin to the `plugins` block in the root `build.gradle.kts` file. This makes the plugin's classes available on the build script's classpath and resolves the `Unresolved reference 'openapitools'` error.