### PR TITLE
Fix unresolved dependency bundles in app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,8 +67,7 @@ dependencies {
     ksp(libs.hilt.compiler)
     
     // Networking
-    implementation(libs.bundles.retrofit)
-    implementation(libs.bundles.okhttp)
+    implementation(libs.bundles.network)
     
     // Security & Utilities
     implementation(libs.bouncycastle)


### PR DESCRIPTION
Replaced the incorrect `retrofit` and `okhttp` dependency bundles with the correct `network` bundle in `app/build.gradle.kts`. The `retrofit` and `okhttp` bundles were not defined in the version catalog, which caused the build to fail. The `network` bundle contains all the necessary networking libraries.