### PR TITLE
Fix 'Any' type serialization issue in OpenAPI generated code

### DIFF
--- a/app/api/unified-aegenesis-api.yml
+++ b/app/api/unified-aegenesis-api.yml
@@ -942,7 +942,7 @@ components:
       type: object
       properties:
         testType: {type: string, enum: [VISUAL, FUNCTIONAL, PERFORMANCE, ACCESSIBILITY]}
-        parameters: {type: object, additionalProperties: true}
+        parameters: {type: object, additionalProperties: true, "x-field-extra-annotation": "@Contextual"}
 
     ComponentTestResult:
       type: object

--- a/app/api/unified-aegenesis-api.yml
+++ b/app/api/unified-aegenesis-api.yml
@@ -942,7 +942,7 @@ components:
       type: object
       properties:
         testType: {type: string, enum: [VISUAL, FUNCTIONAL, PERFORMANCE, ACCESSIBILITY]}
-        parameters: {type: object, additionalProperties: true, "x-field-extra-annotation": "@Contextual"}
+        parameters: {type: object, additionalProperties: true, x-field-extra-annotation: "@Contextual"}
        
 
 


### PR DESCRIPTION
Added the `x-field-extra-annotation: "@Contextual"` to the `parameters` property of the `ComponentTestRequest` schema in the OpenAPI spec file. This will make the OpenAPI generator add the `@Contextual` annotation to the generated `Map<String, Any>` property, which should resolve the Kotlin serialization compiler error.